### PR TITLE
[FIX] 메인 데이터를 불러오는 로직 변경

### DIFF
--- a/src/main/java/sopt/market/product/controller/ProductController.java
+++ b/src/main/java/sopt/market/product/controller/ProductController.java
@@ -27,6 +27,7 @@ public class ProductController {
 
     @GetMapping("/v1/products/main")
     public ResponseEntity<SuccessResponse<MainDataGetResponse>> getMainData(){
+
         MainDataGetResponse mainData = productService.getMainData();
         return ResponseEntity.ok().body(success(GET_MAINDATAS.getMessage(), mainData));
 

--- a/src/main/java/sopt/market/product/controller/ProductController.java
+++ b/src/main/java/sopt/market/product/controller/ProductController.java
@@ -1,6 +1,5 @@
 package sopt.market.product.controller;
 
-import org.apache.coyote.Response;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -12,8 +11,8 @@ import sopt.market.product.dto.response.MainDataGetResponse;
 import sopt.market.product.service.ProductService;
 
 import static sopt.market.common.dto.SuccessResponse.success;
-import static sopt.market.product.message.successMessage.GET_DETAILDATAS;
-import static sopt.market.product.message.successMessage.GET_MAINDATAS;
+import static sopt.market.product.message.SuccessMessage.GET_DETAILDATAS;
+import static sopt.market.product.message.SuccessMessage.GET_MAINDATAS;
 
 @RestController
 @RequestMapping("/api")

--- a/src/main/java/sopt/market/product/message/SuccessMessage.java
+++ b/src/main/java/sopt/market/product/message/SuccessMessage.java
@@ -1,10 +1,10 @@
 package sopt.market.product.message;
 
-public enum successMessage {
+public enum SuccessMessage {
     GET_MAINDATAS("메인 화면 데이터 불러오기 성공"),
     GET_DETAILDATAS("상품 상세 데이터 불러오기 성공");
 
-    successMessage(String message) {
+    SuccessMessage(String message) {
         this.message = message;
     }
 

--- a/src/main/java/sopt/market/product/service/ProductService.java
+++ b/src/main/java/sopt/market/product/service/ProductService.java
@@ -13,6 +13,7 @@ import java.util.stream.Collectors;
 
 @Service
 public class ProductService {
+
     private final ProductRepository productRepository;
 
     public ProductService(ProductRepository productRepository){

--- a/src/main/java/sopt/market/product/service/ProductService.java
+++ b/src/main/java/sopt/market/product/service/ProductService.java
@@ -7,6 +7,7 @@ import sopt.market.product.dto.response.MainDataGetResponse;
 import sopt.market.product.entity.Product;
 import sopt.market.product.repository.ProductRepository;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -21,13 +22,18 @@ public class ProductService {
     }
 
     public MainDataGetResponse getMainData(){
-        List<Product> products = productRepository.getRandomProducts(15);
-
-        List<Product> sortedProducts = products.stream()
-                .sorted((p1, p2) -> Integer.compare(p2.getView(), p1.getView()))
+        List<Product> allProducts = productRepository.findAll();
+        List<Product> sorted5Products = allProducts.stream()
+                .sorted((p1,p2)-> Integer.compare(p2.getView(), p1.getView()))
+                .limit(5)
                 .toList();
 
-        return MainDataGetResponse.from(sortedProducts);
+        List<Product> products = productRepository.getRandomProducts(10);
+
+        List<Product> combinedProducts = new ArrayList<>(products);
+        combinedProducts.addAll(sorted5Products);
+
+        return MainDataGetResponse.from(combinedProducts);
     }
 
     public DetailDataGetResponse getDetailData(Long id){

--- a/src/main/java/sopt/market/review/controller/ReviewController.java
+++ b/src/main/java/sopt/market/review/controller/ReviewController.java
@@ -10,7 +10,7 @@ import sopt.market.review.dto.response.ReviewsGetResponse;
 import sopt.market.review.service.ReviewService;
 
 import static sopt.market.common.dto.SuccessResponse.success;
-import static sopt.market.review.messages.successMessage.GET_REVIEWS;
+import static sopt.market.review.messages.SuccessMessage.GET_REVIEWS;
 
 @RestController
 @RequestMapping("/api")

--- a/src/main/java/sopt/market/review/messages/SuccessMessage.java
+++ b/src/main/java/sopt/market/review/messages/SuccessMessage.java
@@ -1,10 +1,10 @@
 package sopt.market.review.messages;
 
-public enum successMessage {
+public enum SuccessMessage {
 
     GET_REVIEWS("리뷰 불러오기 성공");
 
-    successMessage(String message) {
+    SuccessMessage(String message) {
         this.message = message;
     }
 


### PR DESCRIPTION
## ✨ Related Issue
-  #5 

## 📝 기능 구현 명세
- 랜덤으로 15개를 조회수 내림차순으로 반환하던 기존에서, 상위 5위의 조회수를 가지는 상품을 고정으로 내보내고, 10개의 데이터는 랜덤으로 반환하도록 수정하였습니다. 

## 🐥 추가적인 언급 사항
- 이전 코드리뷰에서 말씀해주셨던 사항들도 시간이 된다면 적용해보고 싶어서, 이 브랜치는 머지 후에도 남겨놓았다가 추후 삭제하겠습니다! 